### PR TITLE
refactor(@types/three): `AnimationClip#toJSON` method patch

### DIFF
--- a/types/three/src/animation/AnimationClip.d.ts
+++ b/types/three/src/animation/AnimationClip.d.ts
@@ -41,7 +41,7 @@ export class AnimationClip {
     validate(): boolean;
     optimize(): AnimationClip;
     clone(): this;
-    toJSON(clip: AnimationClip): any;
+    toJSON(): AnimationClipJSON;
 
     static CreateFromMorphTargetSequence(
         name: string,


### PR DESCRIPTION
### Summary

> This PR is the resolution of [[@types/three]: AnimationClip toJSON method is not accurate](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/71594) discussion.

#### Changes

- Remove parameter to the `AnimationClip#toJSON` method
- Replace the return `any` type with the `AnimationClipJson` type